### PR TITLE
グローバルランキングにシャドウバン機能を追加

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -64,6 +64,7 @@ docker exec myapp_db mariadb -u root -ppass -e "SHOW DATABASES;"
 | `v2_save_data_*` | v2 セーブデータの詳細 (実績/各種詳細カウンタ等) | すべて `v2_save_data.id` に FK |
 | `v3_user_latest_save_data` | 最新セーブのサマリ | v3/v4 API のランキング高速化 |
 | `v3_user_latest_save_data_achievements` | 最新セーブの実績一覧 | v3 用キャッシュ |
+| `user_banned` | ランキング除外Userテーブル |
 
 ### 3.2 テーブルサイズ（`SHOW TABLE STATUS` 抜粋）
 
@@ -515,6 +516,20 @@ CREATE TABLE `v2_save_data_ferlot_useitem` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
 ```
 
+### 5.20 user_banned
+
+```sql
+CREATE TABLE `user_banned` (
+  `user_id` varchar(255) NOT NULL,
+  `enabled` tinyint(1) NOT NULL DEFAULT 1,
+  `note` text DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+  `updated_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  PRIMARY KEY (`user_id`),
+  KEY `idx_user_banned_enabled` (`enabled`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+```
+
 ---
 
 ## 6. よく使うクエリ
@@ -536,6 +551,13 @@ SELECT * FROM v3_user_latest_save_data ORDER BY created_at DESC LIMIT 10;
 -- マイグレーション確認
 SELECT * FROM goose_db_version ORDER BY version_id;
 SELECT MAX(version_id) AS latest_version FROM goose_db_version;
+
+-- シャドウBAN管理
+INSERT INTO user_banned (user_id, note) VALUES ('xxxxxxxx', 'reason memo');
+UPDATE user_banned SET enabled = 0 WHERE user_id = 'xxxxxxxx';   -- 無効化
+UPDATE user_banned SET enabled = 1 WHERE user_id = 'xxxxxxxx';   -- 有効化
+DELETE FROM user_banned WHERE user_id = 'xxxxxxxx';              -- 削除
+SELECT * FROM user_banned WHERE enabled = 1;                     -- BANユーザーの一覧
 ```
 
 ---

--- a/integration/repository_v4_test.go
+++ b/integration/repository_v4_test.go
@@ -92,6 +92,7 @@ func cleanupTables(t *testing.T, db *sqlx.DB) {
 		"v3_user_latest_save_data_achievements",
 		"v3_user_latest_save_data",
 		"v2_save_data",
+		"user_banned",
 	}
 
 	if _, err := db.Exec("SET FOREIGN_KEY_CHECKS=0"); err != nil {
@@ -395,6 +396,101 @@ func TestRepositoryV4_StatisticsAndAchievementRates(t *testing.T) {
 	rate := (*rates.AchievementRates)["ach-1"]
 	if rate.Count == nil || *rate.Count != 2 {
 		t.Fatalf("ach-1 count: got %#v", rate.Count)
+	}
+}
+
+func TestRepositoryV4_IsUserBanned(t *testing.T) {
+	db := setupDB(t)
+	repo := repository.New(db)
+
+	ctx := context.Background()
+	userID := "user-banned-1"
+
+	banned, err := repo.IsUserBanned(ctx, userID)
+	if err != nil {
+		t.Fatalf("is banned (none): %v", err)
+	}
+	if banned {
+		t.Fatalf("expected not banned for unknown user")
+	}
+
+	if _, err := db.Exec("INSERT INTO user_banned (user_id, note) VALUES (?, ?)", userID, "test"); err != nil {
+		t.Fatalf("insert ban: %v", err)
+	}
+	banned, err = repo.IsUserBanned(ctx, userID)
+	if err != nil {
+		t.Fatalf("is banned: %v", err)
+	}
+	if !banned {
+		t.Fatalf("expected banned after insert")
+	}
+
+	if _, err := db.Exec("UPDATE user_banned SET enabled = 0 WHERE user_id = ?", userID); err != nil {
+		t.Fatalf("disable ban: %v", err)
+	}
+	banned, err = repo.IsUserBanned(ctx, userID)
+	if err != nil {
+		t.Fatalf("is banned after disable: %v", err)
+	}
+	if banned {
+		t.Fatalf("expected not banned when enabled = 0")
+	}
+}
+
+func TestRepositoryV4_BannedUserForcesHideRecord(t *testing.T) {
+	db := setupDB(t)
+	repo := repository.New(db)
+
+	ctx := context.Background()
+	userID := "user-banned-save"
+
+	if _, err := db.Exec("INSERT INTO user_banned (user_id) VALUES (?)", userID); err != nil {
+		t.Fatalf("insert ban: %v", err)
+	}
+
+	sd := newSaveData(userID, 10, 100, []string{"ach-1"})
+	sd.HideRecord = 0 // クライアントが0を送ってきた想定
+
+	banned, err := repo.IsUserBanned(ctx, userID)
+	if err != nil {
+		t.Fatalf("is banned: %v", err)
+	}
+	if banned {
+		sd.HideRecord = 1
+	}
+	if err := repo.InsertSaveV4(ctx, sd); err != nil {
+		t.Fatalf("insert save: %v", err)
+	}
+
+	var hide int
+	if err := db.Get(&hide, "SELECT hide_record FROM v3_user_latest_save_data WHERE user_id = ?", userID); err != nil {
+		t.Fatalf("select hide_record: %v", err)
+	}
+	if hide != 1 {
+		t.Fatalf("hide_record after ban: got %d, want 1", hide)
+	}
+
+	// BAN無効化後の再セーブでhide_record=0が通ることを確認
+	if _, err := db.Exec("UPDATE user_banned SET enabled = 0 WHERE user_id = ?", userID); err != nil {
+		t.Fatalf("disable ban: %v", err)
+	}
+	sd2 := newSaveData(userID, 20, 200, []string{"ach-1"})
+	sd2.HideRecord = 0
+	banned, err = repo.IsUserBanned(ctx, userID)
+	if err != nil {
+		t.Fatalf("is banned after disable: %v", err)
+	}
+	if banned {
+		sd2.HideRecord = 1
+	}
+	if err := repo.InsertSaveV4(ctx, sd2); err != nil {
+		t.Fatalf("insert save2: %v", err)
+	}
+	if err := db.Get(&hide, "SELECT hide_record FROM v3_user_latest_save_data WHERE user_id = ?", userID); err != nil {
+		t.Fatalf("select hide_record after unban: %v", err)
+	}
+	if hide != 0 {
+		t.Fatalf("hide_record after unban: got %d, want 0", hide)
 	}
 }
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -51,6 +51,7 @@ type Repository interface {
 	GetCreditAllDistribution(ctx context.Context) (*models.CreditAllDistributionResponse, error)
 
 	ExistsSameSave(ctx context.Context, userID string, playtime int64) (bool, error)
+	IsUserBanned(ctx context.Context, userID string) (bool, error)
 	InsertSaveV4(ctx context.Context, sd *domain.SaveData) error
 	GetLatestSave(ctx context.Context, userID string) (*domain.SaveData, error)
 	GetSaveHistory(ctx context.Context, userID string, limit int, before *time.Time) ([]models.SaveHistoryEntry, bool, error)

--- a/internal/handler/handler_v4.go
+++ b/internal/handler/handler_v4.go
@@ -61,6 +61,16 @@ func (h *Handler) GetV4Data(ctx echo.Context, params models.GetV4DataParams) err
 
 	// 保存（v2_save_data に保存し、v3_user_latest_save_data を更新）
 	sd.UserId = userID
+
+	// シャドウバン (BANリストにヒットしたuser_idはhide_recordを1に強制)
+	banned, err := h.repo.IsUserBanned(ctx.Request().Context(), userID)
+	if err != nil {
+		return ctx.String(http.StatusInternalServerError, err.Error())
+	}
+	if banned {
+		sd.HideRecord = 1
+	}
+
 	if err := h.repo.InsertSaveV4(ctx.Request().Context(), sd); err != nil {
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}

--- a/internal/handler/handler_v4_test.go
+++ b/internal/handler/handler_v4_test.go
@@ -75,6 +75,9 @@ type stubRepo struct {
 
 	creditAllDistribution    *models.CreditAllDistributionResponse
 	creditAllDistributionErr error
+
+	bannedUsers map[string]bool
+	bannedErr   error
 }
 
 func (s *stubRepo) GetRankings(ctx context.Context, sortBy string, limit int) ([]models.GameData, error) {
@@ -115,6 +118,13 @@ func (s *stubRepo) GetCreditAllDistribution(ctx context.Context) (*models.Credit
 
 func (s *stubRepo) ExistsSameSave(ctx context.Context, userID string, playtime int64) (bool, error) {
 	return s.existsSameSave, s.existsErr
+}
+
+func (s *stubRepo) IsUserBanned(ctx context.Context, userID string) (bool, error) {
+	if s.bannedErr != nil {
+		return false, s.bannedErr
+	}
+	return s.bannedUsers[userID], nil
 }
 
 func (s *stubRepo) InsertSaveV4(ctx context.Context, sd *domain.SaveData) error {
@@ -200,6 +210,10 @@ func (r *flowRepo) GetSaveActivity(ctx context.Context, hours int) (*models.Save
 
 func (r *flowRepo) GetCreditAllDistribution(ctx context.Context) (*models.CreditAllDistributionResponse, error) {
 	return &models.CreditAllDistributionResponse{}, nil
+}
+
+func (r *flowRepo) IsUserBanned(ctx context.Context, userID string) (bool, error) {
+	return false, nil
 }
 
 func (r *flowRepo) ExistsSameSave(ctx context.Context, userID string, playtime int64) (bool, error) {

--- a/internal/migration/33_create_user_banned_table.sql
+++ b/internal/migration/33_create_user_banned_table.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- Add global ranking shadow ban table
+
+CREATE TABLE IF NOT EXISTS user_banned (
+    user_id    VARCHAR(255) NOT NULL,
+    enabled    TINYINT(1)   NOT NULL DEFAULT 1,
+    note       TEXT         NULL,
+    created_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id),
+    KEY idx_user_banned_enabled (enabled)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- +goose Down
+DROP TABLE IF EXISTS user_banned;

--- a/internal/repository/ban.go
+++ b/internal/repository/ban.go
@@ -1,0 +1,14 @@
+package repository
+
+import "context"
+
+func (r *Repository) IsUserBanned(ctx context.Context, userID string) (bool, error) {
+	var n int
+	if err := r.db.GetContext(ctx, &n,
+		`SELECT COUNT(*) FROM user_banned WHERE user_id = ? AND enabled = 1`,
+		userID,
+	); err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}


### PR DESCRIPTION
#41 

グローバルランキング不正の暫定対策としてUserID（VRCの表示名）でのBANリストでシャドウバンを実装しました
BANリストにマッチしたユーザーはセーブしようとするとサーバー側で強制的に`hide_record`を1に書き換えて処理することでグローバルランキングから除外します。

ユーザーには通常通り200を返し、クラウドロードも動くので、ユーザーにはシャドウバンされたかを知る余地がない
※グローバルランキングに乗らなくなるのでそこで気づくけど

BANリスト管理は一旦手動、下手に管理エンドポイント生やしても認証で面倒なので...

スキーマ定義は以下。`created_at `,`updated_at `は自動更新なので弄る必要なし

```sql
CREATE TABLE IF NOT EXISTS user_banned (
    user_id    VARCHAR(255) NOT NULL,
    enabled    TINYINT(1)   NOT NULL DEFAULT 1,
    note       TEXT         NULL,
    created_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
    updated_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
    PRIMARY KEY (user_id),
    KEY idx_user_banned_enabled (enabled)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
```